### PR TITLE
Updated dependencies needed by create_minidebuginfo

### DIFF
--- a/build/art.go
+++ b/build/art.go
@@ -88,12 +88,14 @@ func globalFlags(ctx android.LoadHookContext) ([]string, []string) {
 		cflags = append(cflags,
 			"-DART_STACK_OVERFLOW_GAP_arm=8192",
 			"-DART_STACK_OVERFLOW_GAP_arm64=16384",
+			"-DART_STACK_OVERFLOW_GAP_riscv64=16384",
 			"-DART_STACK_OVERFLOW_GAP_x86=16384",
 			"-DART_STACK_OVERFLOW_GAP_x86_64=20480")
 	} else {
 		cflags = append(cflags,
 			"-DART_STACK_OVERFLOW_GAP_arm=8192",
 			"-DART_STACK_OVERFLOW_GAP_arm64=8192",
+			"-DART_STACK_OVERFLOW_GAP_riscv64=8192",
 			"-DART_STACK_OVERFLOW_GAP_x86=8192",
 			"-DART_STACK_OVERFLOW_GAP_x86_64=8192")
 	}

--- a/libartbase/arch/instruction_set.cc
+++ b/libartbase/arch/instruction_set.cc
@@ -27,6 +27,7 @@ void InstructionSetAbort(InstructionSet isa) {
     case InstructionSet::kArm:
     case InstructionSet::kThumb2:
     case InstructionSet::kArm64:
+    case InstructionSet::kRiscv64:
     case InstructionSet::kX86:
     case InstructionSet::kX86_64:
     case InstructionSet::kNone:
@@ -44,6 +45,8 @@ const char* GetInstructionSetString(InstructionSet isa) {
       return "arm";
     case InstructionSet::kArm64:
       return "arm64";
+    case InstructionSet::kRiscv64:
+      return "riscv64";
     case InstructionSet::kX86:
       return "x86";
     case InstructionSet::kX86_64:
@@ -62,6 +65,8 @@ InstructionSet GetInstructionSetFromString(const char* isa_str) {
     return InstructionSet::kArm;
   } else if (strcmp("arm64", isa_str) == 0) {
     return InstructionSet::kArm64;
+  } else if (strcmp("riscv64", isa_str) == 0) {
+    return InstructionSet::kRiscv64;
   } else if (strcmp("x86", isa_str) == 0) {
     return InstructionSet::kX86;
   } else if (strcmp("x86_64", isa_str) == 0) {
@@ -79,6 +84,8 @@ size_t GetInstructionSetAlignment(InstructionSet isa) {
       return kArmAlignment;
     case InstructionSet::kArm64:
       return kArm64Alignment;
+    case InstructionSet::kRiscv64:
+      return kRiscv64Alignment;
     case InstructionSet::kX86:
       // Fall-through.
     case InstructionSet::kX86_64:
@@ -95,6 +102,7 @@ namespace instruction_set_details {
 
 static_assert(IsAligned<kPageSize>(kArmStackOverflowReservedBytes), "ARM gap not page aligned");
 static_assert(IsAligned<kPageSize>(kArm64StackOverflowReservedBytes), "ARM64 gap not page aligned");
+static_assert(IsAligned<kPageSize>(kRiscv64StackOverflowReservedBytes), "RISCV64 gap not page aligned");
 static_assert(IsAligned<kPageSize>(kX86StackOverflowReservedBytes), "X86 gap not page aligned");
 static_assert(IsAligned<kPageSize>(kX86_64StackOverflowReservedBytes),
               "X86_64 gap not page aligned");
@@ -107,6 +115,7 @@ static_assert(IsAligned<kPageSize>(kX86_64StackOverflowReservedBytes),
 static_assert(ART_FRAME_SIZE_LIMIT < kArmStackOverflowReservedBytes, "Frame size limit too large");
 static_assert(ART_FRAME_SIZE_LIMIT < kArm64StackOverflowReservedBytes,
               "Frame size limit too large");
+static_assert(ART_FRAME_SIZE_LIMIT < kRiscv64StackOverflowReservedBytes, "Frame size limit too large");
 static_assert(ART_FRAME_SIZE_LIMIT < kX86StackOverflowReservedBytes,
               "Frame size limit too large");
 static_assert(ART_FRAME_SIZE_LIMIT < kX86_64StackOverflowReservedBytes,

--- a/libelffile/elf/elf_builder.h
+++ b/libelffile/elf/elf_builder.h
@@ -814,6 +814,8 @@ class ElfBuilder final {
         return InstructionSet::kThumb2;
       case EM_AARCH64:
         return InstructionSet::kArm64;
+      case EM_RISCV:
+        return InstructionSet::kRiscv64;
       case EM_386:
         return InstructionSet::kX86;
       case EM_X86_64:
@@ -836,6 +838,11 @@ class ElfBuilder final {
       }
       case InstructionSet::kArm64: {
         elf_header.e_machine = EM_AARCH64;
+        elf_header.e_flags = 0;
+        break;
+      }
+      case InstructionSet::kRiscv64: {
+        elf_header.e_machine = EM_RISCV;
         elf_header.e_flags = 0;
         break;
       }

--- a/libelffile/elf/elf_utils.h
+++ b/libelffile/elf/elf_utils.h
@@ -69,6 +69,8 @@ struct ElfTypes64 {
 
 #define EM_AARCH64 183
 
+#define EM_RISCV 243
+
 #define DT_BIND_NOW 24
 #define DT_INIT_ARRAY 25
 #define DT_FINI_ARRAY 26


### PR DESCRIPTION
Updated dependencies needed by prebuilts/build-tools/linux-x86/bin/create_minidebuginfo, now create_minidebuginfo supports RISC-V. 
Test create_minidebuginfo with the following commands.
```
$ cd /aosp
$ source ./build/envsetup.sh
$ lunch aosp_riscv64-eng
$ cd /aosp/art/tools/create_minidebuginfo/
$ mma
```
Command mma will build create_minidebuginfo itself and all its dependencies. 
When finished, you will see something like
```
[100% 805/805] Install: out/host/linux-x86/bin/create_minidebuginfo
```
So that `out/host/linux-x86/bin/create_minidebuginfo` is the location of the built binary file. We need to use the file we built to replace the prebuilt binary file located in `/aosp/prebuilts/build-tools/linux-x86/bin/`, use the following command:
```
cp /aosp/out/host/linux-x86/bin/create_minidebuginfo /aosp/prebuilts/build-tools/linux-x86/bin/
```
Now, we have already applied the new create_minidebuginfo.
We could try the following compiling command:
```
mmm bionic
```
